### PR TITLE
Fix for issues when using metadata

### DIFF
--- a/pypaystack/transactions.py
+++ b/pypaystack/transactions.py
@@ -69,7 +69,7 @@ class Transaction(BaseAPI):
         if reference:
             payload.update({"reference": reference})
         if metadata:
-            payload = payload.update({"metadata": {"custom_fields": metadata}})
+            payload.update({"metadata": {"custom_fields": metadata}})
 
         return self._handle_request("POST", url, payload)
 


### PR DESCRIPTION
Fixed the bug causing the response 'Invalid Amount Sent' when using metadata in initialize.